### PR TITLE
feat(lua): convert neosh table into a metatable

### DIFF
--- a/src/lua/neosh.lua
+++ b/src/lua/neosh.lua
@@ -97,6 +97,19 @@ end
 --
 end ]]
 
+neosh = setmetatable(neosh, {
+  __index = function(_, key)
+    return function(...)
+      local args = { ... }
+      local cmd = key
+      for _, arg in ipairs(args) do
+        cmd = cmd .. " " .. arg
+      end
+      os.execute(cmd)
+    end
+  end
+})
+
 return neosh
 
 -- vim: sw=2:ts=2:sts=2:tw=100:


### PR DESCRIPTION
Converted our NeoSH Lua table into a metatable so we can call system commands with `neosh.command_name()` syntax.

System commands arguments should be defined inside the command function, e.g. `neosh.ls("~/.local/share/neosh")`.