### PR TITLE
feat(lua): add `log` table to bridge Rust tracing with Lua

### DIFF
--- a/src/core/lua.rs
+++ b/src/core/lua.rs
@@ -1,9 +1,41 @@
 use mlua::prelude::{LuaResult, LuaTable};
 use mlua::Lua;
 
+use tracing::{info, warn, error, debug, trace};
+
 const NEOSH_STDLIB: &str = include_str!("../lua/neosh.lua");
 
-// Initialize Lua globals
+fn info(_: &Lua, msg: String) -> LuaResult<()> {
+    let msg = msg.as_str();
+    info!(msg);
+    Ok(())
+}
+
+fn warn(_: &Lua, msg: String) -> LuaResult<()> {
+    let msg = msg.as_str();
+    warn!(msg);
+    Ok(())
+}
+
+fn error(_: &Lua, msg: String) -> LuaResult<()> {
+    let msg = msg.as_str();
+    error!(msg);
+    Ok(())
+}
+
+fn debug(_: &Lua, msg: String) -> LuaResult<()> {
+    let msg = msg.as_str();
+    debug!(msg);
+    Ok(())
+}
+
+fn trace(_: &Lua, msg: String) -> LuaResult<()> {
+    let msg = msg.as_str();
+    trace!(msg);
+    Ok(())
+}
+
+// Initialize Lua globals and logging
 pub fn init(lua: &Lua) -> LuaResult<LuaTable> {
     // ===== Setup package path so we can require scripts
     lua.load(
@@ -25,5 +57,15 @@ pub fn init(lua: &Lua) -> LuaResult<LuaTable> {
     globals.set("neosh", lua_neosh)?;
 
     lua.load(NEOSH_STDLIB).set_name("neosh")?.exec()?;
+
+    // ===== Set logging functions
+    let lua_log = lua.create_table()?;
+    lua_log.set("info", lua.create_function(info)?)?;
+    lua_log.set("warn", lua.create_function(warn)?)?;
+    lua_log.set("error", lua.create_function(error)?)?;
+    lua_log.set("debug", lua.create_function(debug)?)?;
+    lua_log.set("trace", lua.create_function(trace)?)?;
+    globals.set("log", lua_log)?;
+
     Ok(globals)
 }

--- a/src/lua/neosh.lua
+++ b/src/lua/neosh.lua
@@ -150,6 +150,54 @@ neosh.tbl_filter = function(tbl, func)
     return filtered_tbl
 end
 
+
+--- Merges two or more map-like tables
+--- @tparam string behavior Decides what to do if a key is found in more than one map
+--- @tparam boolean deep_extend Decides if subtables should be also merged
+--- @vararg table
+--- @return table
+--- @private
+local extend_table = function(behavior, deep_extend, ...)
+    if behavior ~= "keep" and behavior ~= "error" and behavior ~= "force" then
+        error(string.format("Invalid tbl_extend behavior: '%s'", behavior))
+    end
+
+    local extended_tbl = {}
+    for i = 1, select("#", ...) do
+        local tbl = select(i, ...)
+        if tbl then
+            for k, v in pairs(tbl) do
+                if deep_extend and type(tbl[k]) == "table" and type(v) == "table" then
+                    extended_tbl[k] = neosh.tbl_extend(behavior, deep_extend, tbl[k], v)
+                elseif behavior ~= "force" and extended_tbl[k] ~= nil then
+                    if behavior == "error" then
+                        error(string.format("Key '%s' found in more than one map", k))
+                    end
+                else
+                    extended_tbl[k] = v
+                end
+            end
+        end
+    end
+    return extended_tbl
+end
+
+--- Merges two or more map-like tables
+--- @tparam string behavior Decides what to do if a key is found in more than one map
+--- @vararg table
+--- @return table
+neosh.tbl_extend = function(behavior, ...)
+    extend_table(behavior, false, ...)
+end
+
+--- Deeply merges two or more map-like tables and its sub-tables
+--- @tparam string behavior Decides what to do if a key is found in more than one map
+--- @vararg table
+--- @return table
+neosh.tbl_deep_extend = function(behavior, ...)
+    extend_table(behavior, true, ...)
+end
+
 --- Returns a deep copy of the given object
 --- @tparam any orig
 --- @return any

--- a/src/lua/neosh.lua
+++ b/src/lua/neosh.lua
@@ -90,12 +90,51 @@ neosh.has_key = function(tbl, key)
   return false
 end
 
---- TODO: Splits a string at N instances of a separator
---[[ neostd.split = function(str, sep, kwargs)
---
--- NOTE: kwargs will cover the Neovim 'vim.split' arguments and also a "python-like times to split argument"
---
-end ]]
+--- Splits a string at N instances of a separator
+--- @tparam string str The string to split
+--- @tparam string sep The separator to be used when splitting the string
+--- @tparam table kwargs Extra arguments:
+---         - plain, boolean: pass literal `sep` to `string.find` call
+---         - trim_empty, boolean: remove empty items from the returned table
+---         - splits, number: number of instances to split the string
+--- @return table
+neosh.split = function(str, sep, kwargs)
+    if not sep then
+        sep = "%s"
+    end
+    kwargs = kwargs or {}
+    local plain = kwargs.plain
+    local trim_empty = kwargs.trim_empty
+    local splits = kwargs.splits or -1
+
+    local str_tbl = {}
+    local nField, nStart = 1, 1
+    local nFirst, nLast
+    if plain then
+        nFirst, nLast = str:find(sep, nStart, plain)
+    else
+        nFirst, nLast = str:find(sep, nStart)
+    end
+
+    while nFirst and splits ~= 0 do
+        str_tbl[nField] = str:sub(nStart, nFirst - 1)
+        nField = nField + 1
+        nStart = nLast + 1
+        nFirst, nLast = str:find(sep, nStart)
+        splits = splits - 1
+    end
+    str_tbl[nField] = str:sub(nStart)
+
+    if trim_empty then
+        for i = #str_tbl, 1, -1 do
+          if str_tbl[i] == "" then
+            table.remove(str_tbl, i)
+          end
+        end
+    end
+
+    return str_tbl
+end
 
 neosh = setmetatable(neosh, {
   __index = function(_, key)
@@ -112,4 +151,4 @@ neosh = setmetatable(neosh, {
 
 return neosh
 
--- vim: sw=2:ts=2:sts=2:tw=100:
+-- vim: sw=4:ts=4:sts=4:tw=100:

--- a/src/lua/neosh.lua
+++ b/src/lua/neosh.lua
@@ -150,6 +150,17 @@ neosh.tbl_filter = function(tbl, func)
     return filtered_tbl
 end
 
+--- Apply a function to all values of a table
+--- @tparam table tbl
+--- @tparam function func
+--- @return table
+neosh.tbl_map = function(tbl, func)
+    local map_tbl = {}
+    for k, v in pairs(tbl) do
+        map_tbl[k] = func(v)
+    end
+    return map_tbl
+end
 
 --- Merges two or more map-like tables
 --- @tparam string behavior Decides what to do if a key is found in more than one map

--- a/src/lua/neosh.lua
+++ b/src/lua/neosh.lua
@@ -14,52 +14,52 @@ neosh.prompt = require("neosh.prompt")
 
 --- Pretty print the given objects
 neosh.fprint = function(...)
-  local args = { ... }
-  for _, arg in ipairs(args) do
-    print(neosh.inspect(arg))
-  end
+    local args = { ... }
+    for _, arg in ipairs(args) do
+        print(neosh.inspect(arg))
+    end
 end
 
 --- Check if string is empty or if it is nil
 --- @tparam str string The string to be checked
 --- @return boolean
 neosh.is_empty = function(str)
-  return str == "" or str == nil
+    return str == "" or str == nil
 end
 
 --- Escape special characters in a string
 --- @tparam string str The string to be escaped
 --- @return string
 neosh.escape_str = function(str)
-  local escape_patterns = {
-    "%^",
-    "%$",
-    "%(",
-    "%)",
-    "%[",
-    "%]",
-    "%%",
-    "%.",
-    "%-",
-    "%*",
-    "%+",
-    "%?",
-  }
+    local escape_patterns = {
+        "%^",
+        "%$",
+        "%(",
+        "%)",
+        "%[",
+        "%]",
+        "%%",
+        "%.",
+        "%-",
+        "%*",
+        "%+",
+        "%?",
+    }
 
-  return str:gsub(("([%s])"):format(table.concat(escape_patterns)), "%%%1")
+    return str:gsub(("([%s])"):format(table.concat(escape_patterns)), "%%%1")
 end
 
 --- Extract the given table keys names and returns them
 --- @tparam table tbl The table to extract its keys
 --- @return table
 neosh.tbl_keys = function(tbl)
-  local keys = {}
+    local keys = {}
 
-  for key, _ in pairs(tbl) do
-    table.insert(keys, key)
-  end
+    for key, _ in pairs(tbl) do
+        table.insert(keys, key)
+    end
 
-  return keys
+    return keys
 end
 
 --- Search if a table contains a value
@@ -67,13 +67,13 @@ end
 --- @tparam any val The value to be looked for
 --- @return boolean
 neosh.has_value = function(tbl, val)
-  for _, value in ipairs(tbl) do
-    if value == val then
-      return true
+    for _, value in ipairs(tbl) do
+        if value == val then
+            return true
+        end
     end
-  end
 
-  return false
+    return false
 end
 
 --- Search if a table contains a key
@@ -81,13 +81,13 @@ end
 --- @tparam string key The key to be looked for
 --- @return boolean
 neosh.has_key = function(tbl, key)
-  for _, k in ipairs(neosh.tbl_keys(tbl)) do
-    if k == key then
-      return true
+    for _, k in ipairs(neosh.tbl_keys(tbl)) do
+        if k == key then
+            return true
+        end
     end
-  end
 
-  return false
+    return false
 end
 
 --- Splits a string at N instances of a separator
@@ -127,26 +127,75 @@ neosh.split = function(str, sep, kwargs)
 
     if trim_empty then
         for i = #str_tbl, 1, -1 do
-          if str_tbl[i] == "" then
-            table.remove(str_tbl, i)
-          end
+            if str_tbl[i] == "" then
+                table.remove(str_tbl, i)
+            end
         end
     end
 
     return str_tbl
 end
 
-neosh = setmetatable(neosh, {
-  __index = function(_, key)
-    return function(...)
-      local args = { ... }
-      local cmd = key
-      for _, arg in ipairs(args) do
-        cmd = cmd .. " " .. arg
-      end
-      os.execute(cmd)
+--- Filter a table using a predicate function
+--- @tparam table tbl
+--- @tparam function func
+--- @return table
+neosh.tbl_filter = function(tbl, func)
+    local filtered_tbl = {}
+    for _, value in pairs(tbl) do
+        if func(value) then
+            table.insert(filtered_tbl, value)
+        end
     end
-  end
+    return filtered_tbl
+end
+
+--- Returns a deep copy of the given object
+--- @tparam any orig
+--- @return any
+neosh.deep_copy = function(orig)
+    local copy
+    local orig_type = type(orig)
+    if orig_type == "table" then
+        copy = {}
+        for orig_key, orig_value in next, orig, nil do
+            copy[neosh.deep_copy(orig_key)] = neosh.deep_copy(orig_value)
+        end
+        setmetatable(copy, neosh.deep_copy(getmetatable(orig)))
+    else
+        copy = orig
+    end
+
+    return copy
+end
+
+--- Check if strings starts with given pattern
+--- @tparam string str
+--- @tparam string pattern
+--- @return boolean
+neosh.starts_with = function(str, pattern)
+    return str:sub(1, #pattern) == pattern
+end
+
+--- Check if strings ends with given pattern
+--- @tparam string str
+--- @tparam string pattern
+--- @return boolean
+neosh.ends_with = function(str, pattern)
+    return str:sub(-#pattern) == pattern
+end
+
+neosh = setmetatable(neosh, {
+    __index = function(_, key)
+        return function(...)
+            local args = { ... }
+            local cmd = key
+            for _, arg in ipairs(args) do
+                cmd = cmd .. " " .. arg
+            end
+            os.execute(cmd)
+        end
+    end
 })
 
 return neosh


### PR DESCRIPTION
The `log` table wraps Rust tracing crate logging functions so we can access _and use_ them in Lua (`info`, `warn`, `error`, `debug`, `trace`).

**IMPORTANT**: this should be merged after #9 