### PR TITLE
fix(lua): directly load NeoSH Lua stdlib related Lua modules using `include_bytes!` macro

### DIFF
--- a/src/core/lua.rs
+++ b/src/core/lua.rs
@@ -5,7 +5,8 @@ use mlua::Lua;
 
 use tracing::{debug, error, info, trace, warn};
 
-const NEOSH_STDLIB: &str = include_str!("../lua/neosh.lua");
+const NEOSH_STDLIB: &[u8] = include_bytes!("../lua/neosh.lua");
+const NEOSH_INSPECT: &[u8] = include_bytes!("../lua/inspect.lua");
 
 /// Generate log functions that can be bridged into Lua
 macro_rules! import_log {
@@ -27,39 +28,29 @@ import_log!(trace);
 /// Initialize Lua globals and logging
 pub fn init(lua: &Lua) -> LuaResult<LuaTable> {
     debug!("Initializing NeoSH Lua stdlib");
-    // ===== Setup package path so we can require scripts
-    lua.load(
-        r#"
-        -- Get the system separator so we can deal with Windows' complex of being unique
-        local sep = package.config:sub(1, 1)
-        -- Update path
-        package.path = table.concat({package.path, string.format(";.%ssrc%slua%s?.lua", sep, sep, sep)})
-    "#,
-    )
-    .exec()?;
-    debug!("Set up package path");
-
     let globals = lua.globals();
 
     // ===== Load NeoSH Lua scripts and functions
-    // Load NeoSH extended Lua stdlib + inspect function
+    // Load NeoSH extended Lua stdlib + inspect function + logs
     let lua_neosh = lua.create_table()?;
 
-    globals.set("neosh", lua_neosh)?;
-
-    lua.load(NEOSH_STDLIB).set_name("neosh")?.exec()?;
-    debug!("Loaded NeoSH Lua stdlib");
-
-    // ===== Set logging functions
+    // Set logging functions and expose them as 'neosh.log'
     let lua_log = lua.create_table()?;
     lua_log.set("info", lua.create_function(info)?)?;
     lua_log.set("warn", lua.create_function(warn)?)?;
     lua_log.set("error", lua.create_function(error)?)?;
     lua_log.set("debug", lua.create_function(debug)?)?;
     lua_log.set("trace", lua.create_function(trace)?)?;
-    globals.set("log", lua_log)?;
+    lua_neosh.set("log", lua_log)?;
 
-    debug!("Set up logging for Lua");
+    debug!("Set up logging for Neosh Lua stdlib");
+    globals.set("neosh", lua_neosh)?;
+
+    // Load NeoSH stdlib
+    lua.load(NEOSH_STDLIB).set_name("neosh")?.exec()?;
+    lua.load(NEOSH_INSPECT).set_name("inspect")?.exec()?;
+
+    debug!("Loaded NeoSH Lua stdlib");
 
     Ok(globals)
 }

--- a/src/lua/inspect.lua
+++ b/src/lua/inspect.lua
@@ -1,3 +1,6 @@
+-- Get global NeoSH stdlib metatable
+local neosh = neosh or {}
+
 local inspect = {
     _VERSION = "inspect.lua 3.1.0",
     _URL = "http://github.com/kikito/inspect.lua",
@@ -397,5 +400,8 @@ setmetatable(inspect, {
         return inspect.inspect(...)
     end,
 })
+
+-- Set NeoSH global metatable inspect field
+neosh.inspect = inspect
 
 return inspect

--- a/src/lua/neosh.lua
+++ b/src/lua/neosh.lua
@@ -251,7 +251,7 @@ neosh = setmetatable(neosh, {
             local args = { ... }
             local cmd = key
             for _, arg in ipairs(args) do
-                cmd = table.concat({ cmd, arg }, " ")
+                cmd = cmd .. " " .. arg
             end
             os.execute(cmd)
         end

--- a/src/lua/neosh.lua
+++ b/src/lua/neosh.lua
@@ -9,8 +9,9 @@
 local neosh = neosh or {}
 
 --- Return human-readable tables
-neosh.inspect = require("inspect")
-neosh.prompt = require("neosh.prompt")
+--- NOTE: this field is going to be populated when requiring 'inspect.lua'
+neosh.inspect = {}
+-- neosh.prompt = neosh.prompt or require("neosh.prompt")
 
 --- Pretty print the given objects
 neosh.fprint = function(...)
@@ -49,7 +50,7 @@ neosh.escape_str = function(str)
     return str:gsub(("([%s])"):format(table.concat(escape_patterns)), "%%%1")
 end
 
---- Extract the given table keys names and returns them
+--- Extract the given map-like table keys names and returns them
 --- @tparam table tbl The table to extract its keys
 --- @return table
 neosh.tbl_keys = function(tbl)
@@ -76,7 +77,7 @@ neosh.has_value = function(tbl, val)
     return false
 end
 
---- Search if a table contains a key
+--- Search if a map-like table contains a key
 --- @tparam table tbl The table to look for the given key
 --- @tparam string key The key to be looked for
 --- @return boolean
@@ -250,7 +251,7 @@ neosh = setmetatable(neosh, {
             local args = { ... }
             local cmd = key
             for _, arg in ipairs(args) do
-                cmd = cmd .. " " .. arg
+                cmd = table.concat({ cmd, arg }, " ")
             end
             os.execute(cmd)
         end


### PR DESCRIPTION
This PR aims to solve NeoSH crashing when used outside of its repository directory by directly loading all required NeoSH Lua modules using `include_bytes!` macro combined with `Lua::load`.

This PR also has some other small changes to codebase, these changes are listed below:
- Removal of Lua `package.path` modifications, we do not need this change anymore.
- Expose Lua `log` table as `neosh.log` and not as a global table.
- Declare `neosh.inspect` as an empty table in `neosh.lua` and populate it into `inspect.lua`.
- Disable loading of `neosh.prompt` Lua module since it is just a proof of concept module.
- Small adjusts to some `neosh.lua` module functions documentation.

Fixes: #27