### PR TITLE
feat(input): add `Home` and `End` keys

### DIFF
--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -1,4 +1,4 @@
-use std::{io::Stdout, time::Duration};
+use std::{convert::TryInto, io::Stdout, time::Duration};
 
 use crossterm::{
     cursor,
@@ -91,6 +91,20 @@ impl KeyHandler {
                 self.index = 0;
                 self.execute = true;
                 println!();
+            }
+            // HOME
+            KeyEvent {
+                code: KeyCode::Home,
+                ..
+            } => {
+                self.index = 0;
+            }
+            // END
+            KeyEvent {
+                code: KeyCode::End, ..
+            } => {
+                let buffer_len = self.buffer.len().try_into().unwrap();
+                self.index = buffer_len;
             }
             // Arrows
             KeyEvent {

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -94,8 +94,7 @@ impl KeyHandler {
             }
             // HOME
             KeyEvent {
-                code: KeyCode::Home,
-                ..
+                code: KeyCode::Home, ..
             } => {
                 self.index = 0;
             }
@@ -103,7 +102,7 @@ impl KeyHandler {
             KeyEvent {
                 code: KeyCode::End, ..
             } => {
-                let buffer_len = self.buffer.len().try_into().unwrap();
+                let buffer_len: u16 = self.buffer.len().try_into().unwrap();
                 self.index = buffer_len;
             }
             // Arrows


### PR DESCRIPTION
This PR aims to implement detection of `Home` and `End` keys. Both keys controls current buffer index, where `Home` moves cursor to the start of user input and `End` moves cursor to the end of user input.