### PR TITLE
feat: implement history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,13 @@ crossterm = "0.22.1"                # User input handler
 tracing = "0.1.29"                  #
 tracing-appender = "0.2.0"          # Logging
 
-[dependencies.mlua]                 # Lua interpreter
-version = "0.6.6"                   #
+[target.'cfg(target_os = "windows")'.dependencies.mlua]
+version = "0.6.6"                   # Lua interpreter for Windows
 features = ["vendored", "luajit"]   # Build LuaJIT on `cargo build`
+
+[target.'cfg(not(target_os = "windows"))'.dependencies.mlua]
+version = "0.6.6"                   # Lua interpreter not for Windows
+features = ["luajit"]               # Build LuaJIT on `cargo build`
 
 [dependencies.tracing-subscriber]   # Logging subscriber
 version = "0.3.3"                   #

--- a/src/core/commands.rs
+++ b/src/core/commands.rs
@@ -29,22 +29,23 @@ pub fn cd(args: SplitWhitespace) -> miette::Result<i64> {
 
     // Raise an error if directory does not exists
     if !next_dir.exists() {
-        eprintln!(
-            "Failed to change directory: directory {} does not exists.",
+        eprintln!("{:?}", miette!(
+            "Failed to change directory: directory {} does not exist.",
             next_dir.to_string_lossy()
-        );
+        ).wrap_err("cd command error"));
         exit_code = 1;
     }
 
     // Raise an error if path exists but it is not a directory
     if !next_dir.is_dir() && next_dir.exists() {
         exit_code = 1;
-        eprintln!(
+        eprintln!("{:?}", miette!(
             "Failed to change directory: {} is not a directory.",
             next_dir.to_string_lossy()
-        );
+        ).wrap_err("cd command error"));
     }
 
+    // Store error in logs
     if let Err(err) = env::set_current_dir(next_dir) {
         exit_code = 1;
         error!("Failed to change directory: {}", err);

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -1,0 +1,44 @@
+//! NeoSH files
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use tracing::debug;
+use miette::{IntoDiagnostic, Result};
+
+pub struct NeoshHistory {
+    pub path: PathBuf,
+}
+
+impl NeoshHistory {
+    pub fn init(&self) -> Result<()> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(self.path.as_path())
+            .into_diagnostic()?;
+
+        Ok(())
+    }
+
+    pub fn get(&self) -> Result<String> {
+        let history = fs::read_to_string(self.path.as_os_str()).into_diagnostic()?;
+        Ok(history)
+    }
+
+    pub fn save(&self, contents: &str) -> Result<()> {
+        let mut history_file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .open(self.path.as_path())
+            .into_diagnostic()?;
+
+        // History file syntax:
+        // exit_code: command
+        writeln!(history_file, "{contents}").into_diagnostic()?;
+
+        debug!("Appended '{contents}' to history");
+        Ok(())
+    }
+}

--- a/src/core/lua.rs
+++ b/src/core/lua.rs
@@ -41,7 +41,7 @@ pub fn init(lua: &Lua) -> LuaResult<LuaTable> {
     // Expose built-in NeoSH commands to Lua side (except exit command because it does nothing)
     let cd_fn = lua.create_function(|_, path: Option<String>| {
         // If no path was passed then fallback to $HOME
-        commands::cd(path.unwrap_or_else(|| "".to_string()).split_whitespace()).unwrap_or(());
+        commands::cd(path.unwrap_or_else(|| "".to_string()).split_whitespace()).unwrap_or(0);
         Ok(())
     })?;
     lua_neosh.set("cd", cd_fn)?;

--- a/src/core/lua.rs
+++ b/src/core/lua.rs
@@ -41,7 +41,7 @@ pub fn init(lua: &Lua) -> LuaResult<LuaTable> {
     // Expose built-in NeoSH commands to Lua side (except exit command because it does nothing)
     let cd_fn = lua.create_function(|_, path: Option<String>| {
         // If no path was passed then fallback to $HOME
-        commands::cd(path.unwrap_or_else(|| "".to_string()).split_whitespace()).unwrap_or(0);
+        commands::cd(path.unwrap_or_else(|| "".to_string()).split_whitespace()).unwrap_or(1);
         Ok(())
     })?;
     lua_neosh.set("cd", cd_fn)?;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,5 +2,6 @@ pub const VERSION: &str = "0.0.1";
 
 pub mod commands;
 pub mod fs;
+pub mod history;
 pub mod input;
 pub mod lua;

--- a/src/lua/neosh.lua
+++ b/src/lua/neosh.lua
@@ -385,6 +385,9 @@ neosh = setmetatable(neosh, {
             for _, arg in ipairs(args) do
                 cmd = cmd .. " " .. arg
             end
+            -- TODO(NTBBloodbath): Look for a way to execute system commands and get their
+            --                     exit code and check if command exists so we can save
+            --                     'neosh.system_cmd(args)' into history
             os.execute(cmd)
         end
     end,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
 use crossterm::{cursor, execute, style::Print, terminal};
 use miette::{miette, IntoDiagnostic, WrapErr};
 use mlua::{Error as LuaError, Lua, MultiValue};
-use neosh::core::{self, commands, fs, input, lua as nlua};
+use neosh::core::{self, commands, fs, history, input, lua as nlua};
 use std::io::stdout;
 use tracing::{debug, info};
 
 fn init() -> miette::Result<fs::NeoshPaths> {
+    // Set up NeoSH directories
     let mut data = dirs::data_dir().ok_or_else(|| miette!("Couldn't get data directory"))?;
     let mut cache = dirs::cache_dir().ok_or_else(|| miette!("Couldn't get cache directory"))?;
     let mut config = dirs::config_dir().ok_or_else(|| miette!("Couldn't get config directory"))?;
-
     data.push("neosh");
     cache.push("neosh");
     config.push("neosh");
@@ -25,6 +25,7 @@ fn init() -> miette::Result<fs::NeoshPaths> {
         .into_diagnostic()
         .wrap_err("Failed to create NeoSH core directories")?;
 
+    // Set NEOSH_VERSION environment variable
     std::env::set_var("NEOSH_VERSION", core::VERSION);
 
     Ok(neosh_paths)
@@ -34,7 +35,15 @@ fn main() -> miette::Result<()> {
     // show panics with miette's fancy messages
     miette::set_panic_hook();
     let neosh_paths = init();
-    let _log_guard = neosh::log::setup(&neosh_paths.wrap_err("Error getting directories")?.data);
+    let neosh_data = &neosh_paths.wrap_err("Error getting directories")?.data;
+    let _log_guard = neosh::log::setup(neosh_data);
+
+    // Set history file path and create history file if not exists
+    let mut history_path = neosh_data.clone();
+    history_path.push("neosh_history");
+    let history = history::NeoshHistory { path: history_path };
+    history.init()?;
+
     let lua = Lua::new();
     info!("Set up Lua instance");
 
@@ -65,17 +74,34 @@ fn main() -> miette::Result<()> {
             let command = args.next().unwrap_or("");
             match command {
                 "exit" => {
+                    history.save("0: exit")?;
                     commands::exit();
                     break;
                 }
                 "cd" => {
-                    commands::cd(args)?;
+                    let path = args.clone();
+                    let exit_code = commands::cd(args)?;
+                    let cmd = format!(
+                        "{}: {} {}",
+                        exit_code,
+                        "cd",
+                        path.collect::<Vec<&str>>().join(" ")
+                    );
+                    history.save(&cmd)?;
                 }
                 "pwd" => {
                     commands::pwd()?;
+                    history.save("0: pwd")?;
                 }
                 "echo" => {
+                    let echo_args = args.clone();
                     commands::echo(args);
+                    let cmd = format!(
+                        "0: {} {}",
+                        "echo",
+                        echo_args.collect::<Vec<&str>>().join(" ")
+                    );
+                    history.save(&cmd)?;
                 }
                 "" => (),
                 _ => match lua
@@ -91,6 +117,8 @@ fn main() -> miette::Result<()> {
                                 .collect::<Vec<_>>()
                                 .join("\t")
                         );
+                        let cmd = format!("0: {prev}{}", &handler.buffer);
+                        history.save(&cmd)?;
                     }
                     Err(LuaError::SyntaxError {
                         incomplete_input: true,
@@ -101,6 +129,8 @@ fn main() -> miette::Result<()> {
                     Err(err) => {
                         terminal::disable_raw_mode().into_diagnostic()?;
                         println!("{:?}", miette!(err).wrap_err("Lua Error"));
+                        let cmd = format!("1: {prev}{}", &handler.buffer);
+                        history.save(&cmd)?;
                         terminal::enable_raw_mode().into_diagnostic()?;
                     }
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main() -> miette::Result<()> {
             let command = args.next().unwrap_or("");
             match command {
                 "exit" => {
-                    history.save("0: exit")?;
+                    history.save("0:exit")?;
                     commands::exit();
                     break;
                 }
@@ -91,13 +91,13 @@ fn main() -> miette::Result<()> {
                 }
                 "pwd" => {
                     commands::pwd()?;
-                    history.save("0: pwd")?;
+                    history.save("0:pwd")?;
                 }
                 "echo" => {
                     let echo_args = args.clone();
                     commands::echo(args);
                     let cmd = format!(
-                        "0: {} {}",
+                        "0:{} {}",
                         "echo",
                         echo_args.collect::<Vec<&str>>().join(" ")
                     );
@@ -117,7 +117,7 @@ fn main() -> miette::Result<()> {
                                 .collect::<Vec<_>>()
                                 .join("\t")
                         );
-                        let cmd = format!("0: {prev}{}", &handler.buffer);
+                        let cmd = format!("0:{prev}{}", &handler.buffer);
                         history.save(&cmd)?;
                     }
                     Err(LuaError::SyntaxError {
@@ -129,7 +129,7 @@ fn main() -> miette::Result<()> {
                     Err(err) => {
                         terminal::disable_raw_mode().into_diagnostic()?;
                         println!("{:?}", miette!(err).wrap_err("Lua Error"));
-                        let cmd = format!("1: {prev}{}", &handler.buffer);
+                        let cmd = format!("1:{prev}{}", &handler.buffer);
                         history.save(&cmd)?;
                         terminal::enable_raw_mode().into_diagnostic()?;
                     }


### PR DESCRIPTION
This PR aims to re-implement history saving, closing #23 by implementing last missing feature on that issue.

These changes are still in a very early stage, currently we are capable of creating history file (it is being created at data directory and is named `neosh_history`, e.g. this is the path in *nix systems: `~/.local/share/neosh/neosh_history`) and saving it.

We are saving everything we can right now, that means we are saving built-in commands history with their exit codes (some of them are hard-coded to `0` at the moment due to their nature, e.g. `echo` or `pwd`), Lua chunks (NeoSH stdlib, Lua stdlib, functions, variables declaration, etc) and failed Lua commands.

Missing functionalities to be added before merging:
- [ ] Refact `history::get` to return a vector with each history line instead of returning history as a string (this can be really hard for Lua chunks with incomplete input like functions in multiple lines).
- [ ] Implement `Up` and `Down` arrow keys in `src/core/input.rs` to browse history, where `Up` gets previous history entry and `Down` gets the next one, like BASH or ZSH.

**Notes**:
1. Second missing functionality task can also include `Page Up` and `Page Down` keys to do the same thing as the `Up` and `Down` arrow keys like in ZSH.
2. As we discussed in our discord server, we want to make a smart history system that does not save commands that had a typo and stuff like that, however, this PR will cover only the core functionality and that logic will be implemented in another PR.