### PR TITLE
chore(Cargo.toml): add NTBBloodbath as an author

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "neosh"
 version = "0.1.0"
 edition = "2018"
-authors = ["Shift", "Vhyrro"]
+authors = ["Shift", "Vhyrro", "NTBBloodbath"]
 description = "A next-gen shell for modern systems"
 repository = "https://github.com/neo-sh/neosh"
 homepage = "https://github.com/neo-sh/neosh"


### PR DESCRIPTION
As discussed in NeoSH discord server a few months ago, I'm back at NeoSH core development team. We forgot to re-add me as an author in `Cargo.toml` tho so this commit adds myself again.

> [Relevant Discord message link](https://discord.com/channels/919290627701735434/919293320080027709/962345157812965406)